### PR TITLE
RemoveJpegFromgitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+*.jpg

--- a/app/assets/stylesheets/messages/messages.scss
+++ b/app/assets/stylesheets/messages/messages.scss
@@ -37,7 +37,8 @@
     }
 }
 .main-body {
-  height: calc(100vh - 120px);
+  overflow: auto;
+  height: calc(100vh - 210px);
   background-color: $gray;
     &__text {
     padding-left: 40px;


### PR DESCRIPTION
# What
.gitignoreの編集
messagesのCSSにoverflowを入れた
# Why
publicに写真が増えないようにするため
スクロールして全ての内容が見られるようにするため